### PR TITLE
Added support for multiple jira project keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ Various inputs are defined in [`action.yml`](action.yml) to let you configure th
 
 Tokens are private, so it's suggested adding them as [GitHub secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets).
 
+## Muliple Jira Project keys
+If you have muliple projects being used in the repo, you can add each poject key to the `jira-project-key` option as follows:
+```
+jira-project-key: |-
+                foo
+                bar
+```
+
 ## In Detail
 
 ### Getting the Jira key from the branch name

--- a/__tests__/jira_client.test.ts
+++ b/__tests__/jira_client.test.ts
@@ -112,3 +112,54 @@ describe("extract jira key", () => {
     expect(jiraKey).toBeUndefined();
   });
 });
+
+describe("extract jira key when given multiple keys", () => {
+  let client: JiraClient;
+
+  beforeEach(() => {
+    client = new JiraClient("base-url", "username", "token", "PRJ\n FOO\n BAR\n");
+  });
+
+  it("extracts the jira key if present", () => {
+    const jiraKey = client.extractJiraKey(
+      "PRJ-3721_actions-workflow-improvements",
+    );
+    expect(jiraKey?.toString()).toBe("PRJ-3721");
+  });
+
+  it("extracts the jira key if present", () => {
+    const jiraKey = client.extractJiraKey(
+      "FOO-3721_actions-workflow-improvements",
+    );
+    expect(jiraKey?.toString()).toBe("FOO-3721");
+  });
+
+  it("extracts the jira key if present without underscore", () => {
+    const jiraKey = client.extractJiraKey(
+      "PRJ-3721-actions-workflow-improvements",
+    );
+    expect(jiraKey?.toString()).toBe("PRJ-3721");
+  });
+
+  it("extracts the jira key from a feature branch if present", () => {
+    const jiraKey = client.extractJiraKey(
+      "feature/BAR-3721_actions-workflow-improvements",
+    );
+    expect(jiraKey?.toString()).toBe("BAR-3721");
+  });
+
+  it("extracts the jira key case insensitive", () => {
+    const jiraKey = client.extractJiraKey(
+      "PRJ-3721_actions-workflow-improvements",
+    );
+    expect(jiraKey?.toString()).toBe("PRJ-3721");
+  });
+
+  it("returns undefined if not present", () => {
+    const jiraKey = client.extractJiraKey(
+      "prj3721_actions-workflow-improvements",
+    );
+    expect(jiraKey).toBeUndefined();
+  });
+
+});

--- a/dist/index.js
+++ b/dist/index.js
@@ -255,13 +255,28 @@ class JiraClient {
         });
     }
     extractJiraKey(input) {
-        var _a, _b;
-        const regex = new RegExp(`${this.projectKey}-(?<number>\\d+)`, "i");
-        const match = input.match(regex);
-        if (!((_a = match === null || match === void 0 ? void 0 : match.groups) === null || _a === void 0 ? void 0 : _a.number)) {
-            return undefined;
-        }
-        return new JiraKey(this.projectKey, (_b = match === null || match === void 0 ? void 0 : match.groups) === null || _b === void 0 ? void 0 : _b.number);
+        /**
+         * Allows for grabbing of multiple keys when given as the follwoing
+         *  jira-project-key: |-
+                foo
+                bar
+        * or 1 key if given only as
+            jira-project-key: foo
+        */
+        const keys = this.projectKey
+            .split(/[\r\n]/)
+            .map(input => input.trim())
+            .filter(input => input !== ''); // grab 1 or many project keys
+        let matchingKey = undefined;
+        keys.forEach(projectKey => {
+            var _a, _b;
+            const regex = new RegExp(`${projectKey}-(?<number>\\d+)`, "i");
+            const match = input.match(regex);
+            if ((_a = match === null || match === void 0 ? void 0 : match.groups) === null || _a === void 0 ? void 0 : _a.number) {
+                matchingKey = new JiraKey(projectKey, (_b = match === null || match === void 0 ? void 0 : match.groups) === null || _b === void 0 ? void 0 : _b.number);
+            }
+        });
+        return matchingKey;
     }
     getIssue(key) {
         var _a;


### PR DESCRIPTION
### Changed
* Added support for multiple jira project keys

## Use case / reason for change
I have a repo that has is used for several jira projects, and I know several others who have repos which are to 1 repo to 1 jira project. This changes should allow branch matching to a list of project keys to accommodate this use case. 

## main changes

- The `extractJiraKey` function in `jira_client.ts`
- Updated the `jira_client.test.ts` to test for multiple keys while leaving the tests for single key unaltered
- updated the readme to reflect the added support for multiple keys


## example
To pass multiple project keys, rather than 1 you can do the following:
```
jira-project-key: |-
                foo
                bar
```

This should still allow support of the original spec for 1 key:
```
jira-project-key: foo
```

