### PR TITLE
Fetch key from jira

### DIFF
--- a/__tests__/jira_client.test.ts
+++ b/__tests__/jira_client.test.ts
@@ -77,36 +77,36 @@ describe("extract jira key", () => {
     client = new JiraClient("base-url", "username", "token", "PRJ");
   });
 
-  it("extracts the jira key if present", () => {
-    const jiraKey = client.extractJiraKey(
+  it("extracts the jira key if present", async () => {
+    const jiraKey = await client.extractJiraKey(
       "PRJ-3721_actions-workflow-improvements",
     );
     expect(jiraKey?.toString()).toBe("PRJ-3721");
   });
 
-  it("extracts the jira key if present without underscore", () => {
-    const jiraKey = client.extractJiraKey(
+  it("extracts the jira key if present without underscore", async () => {
+    const jiraKey = await client.extractJiraKey(
       "PRJ-3721-actions-workflow-improvements",
     );
     expect(jiraKey?.toString()).toBe("PRJ-3721");
   });
 
-  it("extracts the jira key from a feature branch if present", () => {
-    const jiraKey = client.extractJiraKey(
+  it("extracts the jira key from a feature branch if present", async () => {
+    const jiraKey = await client.extractJiraKey(
       "feature/PRJ-3721_actions-workflow-improvements",
     );
     expect(jiraKey?.toString()).toBe("PRJ-3721");
   });
 
-  it("extracts the jira key case insensitive", () => {
-    const jiraKey = client.extractJiraKey(
+  it("extracts the jira key case insensitive", async () => {
+    const jiraKey = await client.extractJiraKey(
       "PRJ-3721_actions-workflow-improvements",
     );
     expect(jiraKey?.toString()).toBe("PRJ-3721");
   });
 
-  it("returns undefined if not present", () => {
-    const jiraKey = client.extractJiraKey(
+  it("returns undefined if not present", async () => {
+    const jiraKey = await client.extractJiraKey(
       "prj3721_actions-workflow-improvements",
     );
     expect(jiraKey).toBeUndefined();
@@ -120,43 +120,43 @@ describe("extract jira key when given multiple keys", () => {
     client = new JiraClient("base-url", "username", "token", "PRJ\n FOO\n BAR\n");
   });
 
-  it("extracts the jira key if present", () => {
-    const jiraKey = client.extractJiraKey(
+  it("extracts the jira key if present", async () => {
+    const jiraKey = await client.extractJiraKey(
       "PRJ-3721_actions-workflow-improvements",
     );
     expect(jiraKey?.toString()).toBe("PRJ-3721");
   });
 
-  it("extracts the jira key if present", () => {
-    const jiraKey = client.extractJiraKey(
+  it("extracts the jira key if present", async () => {
+    const jiraKey = await client.extractJiraKey(
       "FOO-3721_actions-workflow-improvements",
     );
     expect(jiraKey?.toString()).toBe("FOO-3721");
   });
 
-  it("extracts the jira key if present without underscore", () => {
-    const jiraKey = client.extractJiraKey(
+  it("extracts the jira key if present without underscore", async () => {
+    const jiraKey = await client.extractJiraKey(
       "PRJ-3721-actions-workflow-improvements",
     );
     expect(jiraKey?.toString()).toBe("PRJ-3721");
   });
 
-  it("extracts the jira key from a feature branch if present", () => {
-    const jiraKey = client.extractJiraKey(
+  it("extracts the jira key from a feature branch if present", async () => {
+    const jiraKey = await client.extractJiraKey(
       "feature/BAR-3721_actions-workflow-improvements",
     );
     expect(jiraKey?.toString()).toBe("BAR-3721");
   });
 
-  it("extracts the jira key case insensitive", () => {
-    const jiraKey = client.extractJiraKey(
+  it("extracts the jira key case insensitive", async () => {
+    const jiraKey = await client.extractJiraKey(
       "PRJ-3721_actions-workflow-improvements",
     );
     expect(jiraKey?.toString()).toBe("PRJ-3721");
   });
 
-  it("returns undefined if not present", () => {
-    const jiraKey = client.extractJiraKey(
+  it("returns undefined if not present", async () => {
+    const jiraKey = await client.extractJiraKey(
       "prj3721_actions-workflow-improvements",
     );
     expect(jiraKey).toBeUndefined();

--- a/action.yml
+++ b/action.yml
@@ -13,8 +13,8 @@ inputs:
     description: 'The subdomain of JIRA cloud that you use to access it. Ex: "https://your-domain.atlassian.net"'
     required: true
   jira-project-key:
-    description: "Key of project in jira. First part of issue key"
-    required: true
+    description: "Key of project in jira. First part of issue key, will grab project keys using provided jira credentials if not provided."
+    required: false
     default: ""
   add-label-with-issue-type:
     description: "If set to true, a label with the issue type from Jira will be added to the pull request"

--- a/dist/index.js
+++ b/dist/index.js
@@ -317,7 +317,7 @@ class JiraClient {
         return __awaiter(this, void 0, void 0, function* () {
             var _a;
             try {
-                const res = yield this.client.get(this.getRestApiUrl(`issue/${key}?fields=issuetype,summary,fixVersions`));
+                const res = yield this.client.get(this.getRestApiUrl(`/rest/api/3/issue/${key}?fields=issuetype,summary,fixVersions`));
                 const body = yield res.readBody();
                 const obj = JSON.parse(body);
                 var issuetype = undefined;
@@ -347,7 +347,7 @@ class JiraClient {
         });
     }
     getRestApiUrl(endpoint) {
-        return `${this.baseUrl}/rest/api/3/${endpoint}`;
+        return `${this.baseUrl}${endpoint}`;
     }
 }
 exports.JiraClient = JiraClient;

--- a/dist/index.js
+++ b/dist/index.js
@@ -487,7 +487,7 @@ function run() {
         const jiraBaseUrl = core.getInput("jira-base-url", { required: true });
         const jiraUsername = core.getInput("jira-username", { required: true });
         const jiraToken = core.getInput("jira-token", { required: true });
-        const jiraProjectKey = core.getInput("jira-project-key", { required: true });
+        const jiraProjectKey = core.getInput("jira-project-key", { required: false });
         const addLabelWithIssueType = core.getBooleanInput("add-label-with-issue-type");
         const issueTypeLabelColor = core.getInput("issue-type-label-color") || "FBCA04";
         const issueTypeLabelDescription = core.getInput("issue-type-label-description") || "Jira Issue Type";

--- a/dist/index.js
+++ b/dist/index.js
@@ -265,32 +265,34 @@ class JiraClient {
         });
     }
     extractJiraKey(input) {
-        // if project keys are not set, fetch it using current credentials
-        if (!this.projectKey) {
-            this.getKeys();
-        }
-        /**
-        * Allows for grabbing of multiple keys when given as the follwoing
-        *  jira-project-key: |-
-               foo
-               bar
-       * or 1 key if given only as
-           jira-project-key: foo
-       */
-        const keys = this.projectKey
-            .split(/[\r\n]/)
-            .map(input => input.trim())
-            .filter(input => input !== ''); // grab 1 or many project keys
-        let matchingKey = undefined;
-        keys.forEach(projectKey => {
-            var _a, _b;
-            const regex = new RegExp(`${projectKey}-(?<number>\\d+)`, "i");
-            const match = input.match(regex);
-            if ((_a = match === null || match === void 0 ? void 0 : match.groups) === null || _a === void 0 ? void 0 : _a.number) {
-                matchingKey = new JiraKey(projectKey, (_b = match === null || match === void 0 ? void 0 : match.groups) === null || _b === void 0 ? void 0 : _b.number);
+        return __awaiter(this, void 0, void 0, function* () {
+            // if project keys are not set, fetch it using current credentials
+            if (!this.projectKey) {
+                yield this.getKeys();
             }
+            /**
+            * Allows for grabbing of multiple keys when given as the follwoing
+            *  jira-project-key: |-
+                   foo
+                   bar
+           * or 1 key if given only as
+               jira-project-key: foo
+           */
+            const keys = this.projectKey
+                .split(/[\r\n]/)
+                .map(input => input.trim())
+                .filter(input => input !== ''); // grab 1 or many project keys
+            let matchingKey = undefined;
+            keys.forEach(projectKey => {
+                var _a, _b;
+                const regex = new RegExp(`${projectKey}-(?<number>\\d+)`, "i");
+                const match = input.match(regex);
+                if ((_a = match === null || match === void 0 ? void 0 : match.groups) === null || _a === void 0 ? void 0 : _a.number) {
+                    matchingKey = new JiraKey(projectKey, (_b = match === null || match === void 0 ? void 0 : match.groups) === null || _b === void 0 ? void 0 : _b.number);
+                }
+            });
+            return matchingKey;
         });
-        return matchingKey;
     }
     /**
      * Fetches all project keys from Jira for the current user
@@ -504,7 +506,7 @@ function run() {
             core.info(`🚨 Dependabot, ignoring`);
             return;
         }
-        const jiraKey = jiraClient.extractJiraKey(branchName);
+        const jiraKey = yield jiraClient.extractJiraKey(branchName);
         if (!jiraKey) {
             core.warning("⚠️ No Jira key found in branch name, exiting");
             return;

--- a/dist/index.js
+++ b/dist/index.js
@@ -265,14 +265,18 @@ class JiraClient {
         });
     }
     extractJiraKey(input) {
+        // if project keys are not set, fetch it using current credentials
+        if (!this.projectKey) {
+            this.getKeys();
+        }
         /**
-         * Allows for grabbing of multiple keys when given as the follwoing
-         *  jira-project-key: |-
-                foo
-                bar
-        * or 1 key if given only as
-            jira-project-key: foo
-        */
+        * Allows for grabbing of multiple keys when given as the follwoing
+        *  jira-project-key: |-
+               foo
+               bar
+       * or 1 key if given only as
+           jira-project-key: foo
+       */
         const keys = this.projectKey
             .split(/[\r\n]/)
             .map(input => input.trim())
@@ -287,6 +291,25 @@ class JiraClient {
             }
         });
         return matchingKey;
+    }
+    /**
+     * Fetches all project keys from Jira for the current user
+     * @returns undefined
+     */
+    getKeys() {
+        return __awaiter(this, void 0, void 0, function* () {
+            try {
+                const res = yield this.client.get(this.getRestApiUrl(`/rest/api/3/project`));
+                const body = yield res.readBody();
+                const projects = JSON.parse(body);
+                projects.map((project) => {
+                    this.projectKey += `${project.key}\r\n`; // added as string with \r\n to be split out to an array later 
+                });
+            }
+            catch (error) {
+                console.error("Failed to fetch projects:", error);
+            }
+        });
     }
     getIssue(key) {
         return __awaiter(this, void 0, void 0, function* () {

--- a/src/common/jira_client.ts
+++ b/src/common/jira_client.ts
@@ -42,11 +42,11 @@ export class JiraClient {
     });
   }
 
-  extractJiraKey(input: string): JiraKey | undefined {  
+  async extractJiraKey(input: string): Promise<JiraKey | undefined> {  
    
     // if project keys are not set, fetch it using current credentials
    if (!this.projectKey) { 
-      this.getKeys()
+      await this.getKeys()
     }
 
      /** 

--- a/src/common/jira_client.ts
+++ b/src/common/jira_client.ts
@@ -106,7 +106,7 @@ export class JiraClient {
   async getIssue(key: JiraKey): Promise<JiraIssue | undefined> {
     try {
       const res = await this.client.get(
-        this.getRestApiUrl(`issue/${key}?fields=issuetype,summary,fixVersions`),
+        this.getRestApiUrl(`/rest/api/3/issue/${key}?fields=issuetype,summary,fixVersions`),
       );
       const body: string = await res.readBody();
       const obj = JSON.parse(body);
@@ -142,6 +142,6 @@ export class JiraClient {
   }
 
   private getRestApiUrl(endpoint: string): string {
-    return `${this.baseUrl}/rest/api/3/${endpoint}`;
+    return `${this.baseUrl}${endpoint}`;
   }
 }

--- a/src/common/jira_client.ts
+++ b/src/common/jira_client.ts
@@ -43,7 +43,13 @@ export class JiraClient {
   }
 
   extractJiraKey(input: string): JiraKey | undefined {  
-    /** 
+   
+    // if project keys are not set, fetch it using current credentials
+   if (!this.projectKey) { 
+      this.getKeys()
+    }
+
+     /** 
      * Allows for grabbing of multiple keys when given as the follwoing
      *  jira-project-key: |-
             foo
@@ -71,6 +77,31 @@ export class JiraClient {
     return matchingKey
 
   }
+
+  /**
+   * Fetches all project keys from Jira for the current user
+   * @returns undefined
+   */
+  async getKeys(): Promise<undefined> {
+
+    try {
+      const res = await this.client.get(
+        this.getRestApiUrl(`/rest/api/3/project`),
+      );
+
+      const body: string = await res.readBody();
+      const projects = JSON.parse(body);
+
+      projects.map((project: { key: string }) => {
+        this.projectKey += `${project.key}\r\n`; // added as string with \r\n to be split out to an array later 
+      });
+
+    
+    } catch (error) {
+      console.error("Failed to fetch projects:", error);
+    }
+  }
+
 
   async getIssue(key: JiraKey): Promise<JiraIssue | undefined> {
     try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ export async function run() {
   const jiraBaseUrl = core.getInput("jira-base-url", { required: true });
   const jiraUsername = core.getInput("jira-username", { required: true });
   const jiraToken = core.getInput("jira-token", { required: true });
-  const jiraProjectKey = core.getInput("jira-project-key", { required: true });
+  const jiraProjectKey = core.getInput("jira-project-key", { required: false });
 
   const addLabelWithIssueType = core.getBooleanInput(
     "add-label-with-issue-type",

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,7 +49,7 @@ export async function run() {
     return;
   }
 
-  const jiraKey = jiraClient.extractJiraKey(branchName);
+  const jiraKey = await jiraClient.extractJiraKey(branchName);
 
   if (!jiraKey) {
     core.warning("⚠️ No Jira key found in branch name, exiting");


### PR DESCRIPTION
### Added
* support for pulling the list of Jira projects using the existing credentials if no Jira keys are set in yml. 
* Uses: `https://your-domain.atlassian.net/rest/api/3/project`
### Changed
* No longer requires jira keys in yml.

### Manual Test
* Run a test against changes in the branch without project keys list. 
<img width="1145" alt="Screenshot 2025-01-14 at 10 39 07 AM" src="https://github.com/user-attachments/assets/0fcace64-796a-45c3-9064-ee7c675028da" />




